### PR TITLE
Thermal pipeline skeleton

### DIFF
--- a/src/pipelines/__init__.py
+++ b/src/pipelines/__init__.py
@@ -1,0 +1,1 @@
+"""Pipeline implementations for camera processing."""

--- a/src/pipelines/thermal_pipeline.py
+++ b/src/pipelines/thermal_pipeline.py
@@ -1,0 +1,57 @@
+"""Thermal camera pipeline skeleton with passthrough frames."""
+
+from __future__ import annotations
+
+import time
+from typing import Optional
+
+import cv2
+import numpy as np
+
+from src.config import Config
+from src.logger import get_logger
+
+logger = get_logger("pipeline.thermal")
+
+
+class ThermalPipeline:
+    """Thermal pipeline that reads frames and passes them through."""
+
+    def __init__(self, config: Config, max_frames: Optional[int] = None) -> None:
+        self.config = config
+        self.max_frames = max_frames
+        self._capture: Optional[cv2.VideoCapture] = None
+
+    def _ensure_capture(self) -> cv2.VideoCapture:
+        if self._capture is None:
+            self._capture = cv2.VideoCapture(self.config.camera.url)
+        return self._capture
+
+    def process_frame(self, frame: np.ndarray) -> np.ndarray:
+        """Passthrough frame processing placeholder."""
+        return frame
+
+    def run(self) -> None:
+        """Read frames from thermal camera and passthrough."""
+        capture = self._ensure_capture()
+        if not capture.isOpened():
+            raise RuntimeError("Failed to open thermal camera stream")
+
+        frame_count = 0
+        try:
+            while True:
+                if self.max_frames is not None and frame_count >= self.max_frames:
+                    break
+
+                ok, frame = capture.read()
+                if not ok:
+                    logger.warning("Failed to read thermal frame")
+                    break
+
+                _ = self.process_frame(frame)
+                frame_count += 1
+
+                if self.config.camera.fps > 0:
+                    time.sleep(1 / self.config.camera.fps)
+        finally:
+            capture.release()


### PR DESCRIPTION
## Summary
- add thermal pipeline package with passthrough frame handling
- provide simple frame loop with optional frame limit

## Test plan
- `python -m pytest` (fails: missing `openai` dependency in environment)

Closes #17

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a minimal thermal camera pipeline for reading and passing through frames.
> 
> - Adds `ThermalPipeline` with frame read loop, passthrough `process_frame`, and clean resource release
> - Uses `cv2.VideoCapture` from `config.camera.url`, optional `max_frames`, and FPS-based sleep (`config.camera.fps`)
> - Logs read failures and ensures capture is released; exposes package via `src/pipelines/__init__.py`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1769dd15556e8f94e97bef815c4292e1b47af079. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->