### PR TITLE
Shared event model and schema

### DIFF
--- a/EVENT_SCHEMA.md
+++ b/EVENT_SCHEMA.md
@@ -1,0 +1,46 @@
+# Event Schema
+
+Shared event contract used by pipelines and notification layers.
+
+## Base Event (required fields)
+- `event_id` (string, required): unique id (UUID recommended)
+- `event_type` (string, required): event type, see `EventType`
+- `timestamp` (string, required): ISO-8601 timestamp in UTC
+- `source` (string, required): event producer (e.g. `pipeline`, `mqtt`, `telegram`)
+- `camera_id` (string|null, required): logical camera identifier, null if not applicable
+- `payload` (object, required): event-specific payload data
+- `schema_version` (string, required): schema version, default `1.0`
+
+## Event types and required payload fields
+### `motion`
+- `detected` (bool): motion detected flag
+- `confidence` (number, optional): confidence score (0-1 or 0-100)
+- `objects` (array<string>, optional): detected objects
+- `threat_level` (string, optional): threat level label
+
+### `analysis`
+- `summary` (string): short analysis summary
+- `details` (string, optional): extended analysis text
+- `confidence` (number, optional): analysis confidence
+
+### `alert`
+- `title` (string): alert title
+- `message` (string): alert body
+- `channels` (array<string>, optional): delivery channels (e.g. `mqtt`, `telegram`)
+
+### `health`
+- `status` (string): `ok` | `degraded` | `down`
+- `components` (object, optional): component status map
+
+### `ready`
+- `ready` (bool): readiness indicator
+- `status` (string, optional): `ok` | `degraded` | `down`
+
+## Compatibility rules
+- Pipelines emit `BaseEvent` with `event_type` + `payload` matching the contract.
+- Notification layers consume `BaseEvent` without inspecting pipeline internals.
+- New fields must be added under `payload` to keep backwards compatibility.
+
+## Extension guidance
+- Add new event types to `EventType` and document required payload fields.
+- Avoid breaking changes by keeping `BaseEvent` fields stable.

--- a/src/events.py
+++ b/src/events.py
@@ -1,0 +1,80 @@
+"""Shared event schema for pipelines and notifications."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any, Dict, Optional, Protocol
+from uuid import uuid4
+
+
+class EventType(str, Enum):
+    """Supported event types."""
+
+    MOTION = "motion"
+    ANALYSIS = "analysis"
+    ALERT = "alert"
+    HEALTH = "health"
+    READY = "ready"
+
+
+@dataclass
+class BaseEvent:
+    """Base event contract for pipeline and notification layers."""
+
+    event_id: str
+    event_type: EventType
+    timestamp: datetime
+    source: str
+    camera_id: Optional[str]
+    payload: Dict[str, Any] = field(default_factory=dict)
+    schema_version: str = "1.0"
+
+    def as_dict(self) -> Dict[str, Any]:
+        """Serialize event into a JSON-friendly dictionary."""
+        return {
+            "event_id": self.event_id,
+            "event_type": self.event_type.value,
+            "timestamp": self.timestamp.isoformat(),
+            "source": self.source,
+            "camera_id": self.camera_id,
+            "payload": self.payload,
+            "schema_version": self.schema_version,
+        }
+
+
+def new_event(
+    event_type: EventType,
+    source: str,
+    camera_id: Optional[str] = None,
+    payload: Optional[Dict[str, Any]] = None,
+    timestamp: Optional[datetime] = None,
+    schema_version: str = "1.0",
+) -> BaseEvent:
+    """Create a new BaseEvent with generated id and timestamp."""
+    return BaseEvent(
+        event_id=str(uuid4()),
+        event_type=event_type,
+        timestamp=timestamp or datetime.now(timezone.utc),
+        source=source,
+        camera_id=camera_id,
+        payload=payload or {},
+        schema_version=schema_version,
+    )
+
+
+class EventPublisher(Protocol):
+    """Protocol for publishing events to downstream systems."""
+
+    def publish(self, event: BaseEvent) -> None:
+        """Publish an event to a sink."""
+        ...  # pragma: no cover
+
+
+class EventConsumer(Protocol):
+    """Protocol for handling events from pipelines."""
+
+    def handle(self, event: BaseEvent) -> None:
+        """Handle an incoming event."""
+        ...  # pragma: no cover


### PR DESCRIPTION
## Summary
- define BaseEvent and event interfaces for pipeline/notification use
- document event schema, required fields, and event types
- include extension guidance for backward compatibility

## Test plan
- `python -m pytest` (fails: missing `openai` dependency in environment)

Closes #21