### PR TITLE
Thermal + Color RTSP MVP

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,24 @@ log_level: "INFO"
 ### Thermal kamera örneği
 ```yaml
 camera_url: "rtsp://user:pass@192.168.1.20:554/thermal"
+camera_type: "thermal"
+camera_fps: 5
+motion_sensitivity: 7
+motion_min_area: 500
+motion_cooldown: 5
+yolo_model: "yolov8n"
+yolo_confidence: 0.5
+openai_api_key: "sk-***"
+telegram_enabled: false
+mqtt_topic_prefix: "smart_motion"
+log_level: "INFO"
+```
+
+### Dual (thermal + color) örneği
+```yaml
+camera_type: "dual"
+color_camera_url: "rtsp://user:pass@192.168.1.10:554/stream1"
+thermal_camera_url: "rtsp://user:pass@192.168.1.20:554/thermal"
 camera_fps: 5
 motion_sensitivity: 7
 motion_min_area: 500
@@ -44,6 +62,9 @@ log_level: "INFO"
 ```
 rtsp://<username>:<password>@<ip>:<port>/<path>
 ```
+
+### Sync strategy
+Detaylar icin `SYNC_STRATEGY.md` dokumanina bakabilirsiniz.
 
 ### MQTT opsiyonları
 - `mqtt_topic_prefix`: Topic prefix (örn. `smart_motion`)
@@ -75,6 +96,16 @@ docker build -t thermal-dual-vision \
 ```
 docker run --rm -p 8099:8099 \
   -e CAMERA_URL="rtsp://user:pass@192.168.1.10:554/stream1" \
+  -e OPENAI_API_KEY="sk-***" \
+  thermal-dual-vision
+```
+
+Dual çalışma örneği:
+```
+docker run --rm -p 8099:8099 \
+  -e CAMERA_TYPE="dual" \
+  -e COLOR_CAMERA_URL="rtsp://user:pass@192.168.1.10:554/stream1" \
+  -e THERMAL_CAMERA_URL="rtsp://user:pass@192.168.1.20:554/thermal" \
   -e OPENAI_API_KEY="sk-***" \
   thermal-dual-vision
 ```

--- a/SYNC_STRATEGY.md
+++ b/SYNC_STRATEGY.md
@@ -5,7 +5,7 @@ Bu dokuman thermal ve color akislari icin temel zaman senkronizasyonu yaklasimin
 ## Hedef
 - Iki akisin zaman bazinda hizalanmasi
 - Kisa drift durumlarinda toleransli eslestirme
-- Gelecekte uygulanabilir bir arayuz notu sunmak
+- MVP icin drift/tolerans metriklerini ortaya koymak
 
 ## Metrikler / Alanlar
 Senkronizasyon icin her frame paketinde asagidaki alanlar tutulur:
@@ -29,9 +29,14 @@ Senkronizasyon icin her frame paketinde asagidaki alanlar tutulur:
    - En dusuk `delta_ms` kazanir.
 
 ## Drift / Tolerans Sinirlari
-- `soft_tolerance_ms`: 150 ms (eslestirme tercih eşiği)
-- `hard_tolerance_ms`: 500 ms (eslestirme kesme eşiği)
+- `soft_tolerance_ms`: 150 ms (eslestirme tercih esigi)
+- `hard_tolerance_ms`: 500 ms (eslestirme kesme esigi)
 - `drop_policy`: `hard_tolerance_ms` asilirsa frame eslestirilmez ve "unmatched" olarak isaretlenir.
+
+## MVP cikti
+Her eslenen frame cifti icin:
+- `delta_ms` ve durum (`ok`, `degraded`, `unmatched`) loglanir
+- Genişletilebilir minimal bir birlesik cikti uretilir
 
 ## Arayuz Notlari (Gelecek Uygulama)
 Senkronizasyona uygun ortak frame paketi:

--- a/config.yaml
+++ b/config.yaml
@@ -15,6 +15,8 @@ init: false
 options:
   camera_url: ""
   camera_type: "color"
+  color_camera_url: ""
+  thermal_camera_url: ""
   camera_fps: 5
   motion_sensitivity: 7
   motion_min_area: 500
@@ -39,6 +41,9 @@ options:
 # Options description
 options_description:
   camera_url: "RTSP camera URL (required)."
+  camera_type: "Camera mode: color, thermal, or dual."
+  color_camera_url: "Color RTSP URL (required for dual mode)."
+  thermal_camera_url: "Thermal RTSP URL (required for dual mode)."
   camera_fps: "Frame rate for capture (default: 5)."
   motion_sensitivity: "Motion sensitivity 1-10 (default: 7)."
   motion_min_area: "Minimum motion area in pixels (default: 500)."
@@ -59,7 +64,9 @@ options_description:
 # Schema validation
 schema:
   camera_url: url
-  camera_type: list(color|thermal)
+  camera_type: list(color|thermal|dual)
+  color_camera_url: url?
+  thermal_camera_url: url?
   camera_fps: int(1,30)
   motion_sensitivity: int(1,10)
   motion_min_area: int(100,10000)

--- a/run.sh
+++ b/run.sh
@@ -12,6 +12,8 @@ bashio::log.info "Starting Smart Motion Detector..."
 # Read configuration from Home Assistant
 export CAMERA_URL=$(bashio::config 'camera_url')
 export CAMERA_TYPE=$(bashio::config 'camera_type')
+export COLOR_CAMERA_URL=$(bashio::config 'color_camera_url')
+export THERMAL_CAMERA_URL=$(bashio::config 'thermal_camera_url')
 export CAMERA_FPS=$(bashio::config 'camera_fps')
 export MOTION_SENSITIVITY=$(bashio::config 'motion_sensitivity')
 export MOTION_MIN_AREA=$(bashio::config 'motion_min_area')
@@ -45,6 +47,8 @@ if [ -n "${CAMERA_URL}" ]; then
 else
     bashio::log.warning "Camera URL: [missing]"
 fi
+bashio::log.info "Color Camera URL: $( [ -n "${COLOR_CAMERA_URL}" ] && echo "[set]" || echo "[missing]" )"
+bashio::log.info "Thermal Camera URL: $( [ -n "${THERMAL_CAMERA_URL}" ] && echo "[set]" || echo "[missing]" )"
 bashio::log.info "Motion Sensitivity: ${MOTION_SENSITIVITY}"
 bashio::log.info "YOLO Model: ${YOLO_MODEL}"
 bashio::log.info "Log Level: ${LOG_LEVEL}"

--- a/src/config.py
+++ b/src/config.py
@@ -12,6 +12,8 @@ class CameraConfig:
     fps: int = 5
     resolution: tuple = (1280, 720)
     camera_type: str = "color"
+    color_url: str = ""
+    thermal_url: str = ""
 
 
 @dataclass
@@ -92,6 +94,8 @@ class Config:
         config.camera.url = os.getenv("CAMERA_URL", "")
         config.camera.fps = int(os.getenv("CAMERA_FPS", "5"))
         config.camera.camera_type = os.getenv("CAMERA_TYPE", "color").lower()
+        config.camera.color_url = os.getenv("COLOR_CAMERA_URL", "")
+        config.camera.thermal_url = os.getenv("THERMAL_CAMERA_URL", "")
 
         # Motion
         config.motion.sensitivity = int(os.getenv("MOTION_SENSITIVITY", "7"))
@@ -133,11 +137,16 @@ class Config:
         """Validate configuration and return list of errors."""
         errors = []
 
-        if not self.camera.url:
-            errors.append("Camera URL is required")
+        if self.camera.camera_type not in {"color", "thermal", "dual"}:
+            errors.append("Camera type must be 'color', 'thermal', or 'dual'")
 
-        if self.camera.camera_type not in {"color", "thermal"}:
-            errors.append("Camera type must be 'color' or 'thermal'")
+        if self.camera.camera_type == "dual":
+            if not self.camera.color_url:
+                errors.append("Color camera URL is required for dual mode")
+            if not self.camera.thermal_url:
+                errors.append("Thermal camera URL is required for dual mode")
+        elif not self.camera.url:
+            errors.append("Camera URL is required")
 
         if not self.llm.api_key:
             errors.append("OpenAI API key is required")

--- a/src/main.py
+++ b/src/main.py
@@ -4,9 +4,10 @@ from src.config import Config
 from src.logger import get_logger, setup_logger
 from src.pipelines.base import BasePipeline
 from src.pipelines.color_pipeline import ColorPipeline
+from src.pipelines.dual_pipeline import DualPipeline
 from src.pipelines.thermal_pipeline import ThermalPipeline
 
-PIPELINE_CLASSES = (ThermalPipeline, ColorPipeline)
+PIPELINE_CLASSES = (ThermalPipeline, ColorPipeline, DualPipeline)
 
 
 def main() -> None:

--- a/src/pipelines/dual_pipeline.py
+++ b/src/pipelines/dual_pipeline.py
@@ -1,0 +1,115 @@
+"""Dual RTSP pipeline for thermal + color streams."""
+
+from __future__ import annotations
+
+import threading
+import time
+from typing import Dict, Optional, Tuple
+
+import cv2
+import numpy as np
+
+from src.config import Config
+from src.logger import get_logger
+from src.pipelines.base import BasePipeline
+
+logger = get_logger("pipeline.dual")
+
+
+class DualPipeline(BasePipeline):
+    """Pipeline that reads thermal and color streams in parallel."""
+
+    camera_type = "dual"
+    soft_tolerance_ms = 150
+    hard_tolerance_ms = 500
+
+    def __init__(self, config: Config, max_pairs: Optional[int] = None) -> None:
+        super().__init__(config)
+        self.max_pairs = max_pairs
+        self._stop_event = threading.Event()
+        self._lock = threading.Lock()
+        self._latest_frames: Dict[str, Optional[np.ndarray]] = {"color": None, "thermal": None}
+        self._latest_ts: Dict[str, Optional[float]] = {"color": None, "thermal": None}
+        self._threads: Dict[str, threading.Thread] = {}
+        self._last_pair: Optional[Tuple[float, float]] = None
+
+    def _capture_loop(self, label: str, url: str) -> None:
+        capture = cv2.VideoCapture(url)
+        if not capture.isOpened():
+            logger.error("Failed to open %s stream", label)
+            return
+
+        try:
+            while not self._stop_event.is_set():
+                ok, frame = capture.read()
+                if not ok:
+                    logger.warning("Failed to read %s frame", label)
+                    time.sleep(0.1)
+                    continue
+
+                ts = time.time() * 1000
+                with self._lock:
+                    self._latest_frames[label] = frame
+                    self._latest_ts[label] = ts
+        finally:
+            capture.release()
+
+    def _start_capture_threads(self) -> None:
+        color_url = self.config.camera.color_url or self.config.camera.url
+        thermal_url = self.config.camera.thermal_url or self.config.camera.url
+
+        self._threads["color"] = threading.Thread(
+            target=self._capture_loop, args=("color", color_url), daemon=True
+        )
+        self._threads["thermal"] = threading.Thread(
+            target=self._capture_loop, args=("thermal", thermal_url), daemon=True
+        )
+
+        for thread in self._threads.values():
+            thread.start()
+
+    def _get_pair(self) -> Optional[Tuple[float, float]]:
+        with self._lock:
+            color_ts = self._latest_ts["color"]
+            thermal_ts = self._latest_ts["thermal"]
+
+        if color_ts is None or thermal_ts is None:
+            return None
+        return (color_ts, thermal_ts)
+
+    def run(self) -> None:
+        """Run dual stream capture and emit combined MVP output."""
+        self._start_capture_threads()
+        pair_count = 0
+
+        try:
+            while True:
+                if self.max_pairs is not None and pair_count >= self.max_pairs:
+                    break
+
+                pair = self._get_pair()
+                if pair is None or pair == self._last_pair:
+                    time.sleep(0.05)
+                    continue
+
+                self._last_pair = pair
+                pair_count += 1
+                delta_ms = abs(pair[0] - pair[1])
+
+                status = "ok"
+                if delta_ms > self.hard_tolerance_ms:
+                    status = "unmatched"
+                elif delta_ms > self.soft_tolerance_ms:
+                    status = "degraded"
+
+                logger.info(
+                    "Dual stream sync pair=%s delta_ms=%.1f status=%s",
+                    pair_count,
+                    delta_ms,
+                    status,
+                )
+
+                if self.config.camera.fps > 0:
+                    time.sleep(1 / self.config.camera.fps)
+        finally:
+            self._stop_event.set()


### PR DESCRIPTION
## Summary
- run thermal and color RTSP streams in a single dual pipeline
- add dual mode configuration and documentation examples
- document basic sync strategy and MVP output

## Architecture notes
- DualPipeline reads both streams in parallel threads and pairs latest frames
- pairing uses capture timestamps with soft/hard tolerance thresholds
- output is a minimal paired-frame log for MVP expansion

## Test plan
- `python -m pytest` (fails: missing `openai` dependency in environment)

Closes #24