### PR TITLE
CI fix: add pytest-asyncio

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-          pip install pytest ruff
+          pip install pytest pytest-asyncio ruff
       - name: Lint
         run: ruff check --select F,E9 .
       - name: Tests


### PR DESCRIPTION
## Summary
- install pytest-asyncio in CI to run async tests

## Test/QA
- pytest calistirilmadi (openai modulu eksik: known issue, bloklayici degil)