### PR TITLE
Run fix: add docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+services:
+  app:
+    build:
+      context: .
+      args:
+        BUILD_FROM: ghcr.io/home-assistant/amd64-base:3.19
+    ports:
+      - "8000:8099"
+    environment:
+      CAMERA_URL: ${CAMERA_URL:-dummy://}
+      CAMERA_TYPE: ${CAMERA_TYPE:-color}
+      COLOR_CAMERA_URL: ${COLOR_CAMERA_URL:-}
+      THERMAL_CAMERA_URL: ${THERMAL_CAMERA_URL:-}
+      OPENAI_API_KEY: ${OPENAI_API_KEY:-test}
+      MQTT_DISCOVERY: ${MQTT_DISCOVERY:-false}
+      LOG_LEVEL: ${LOG_LEVEL:-INFO}


### PR DESCRIPTION
## Summary
- add docker-compose.yml with build args and port 8000 mapping
- provide env defaults for local bring-up

## Test/QA
- docker compose build failed before due to missing BUILD_FROM; this PR provides it
- pytest not required (openai missing known issue)