### PR TITLE
Run fix: Dockerfile pip install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ WORKDIR /app
 COPY requirements.txt /app/
 
 # Install Python dependencies
-RUN pip3 install --no-cache-dir -r requirements.txt
+RUN pip3 install --no-cache-dir --break-system-packages -r requirements.txt
 
 # Copy application source
 COPY src/ /app/src/


### PR DESCRIPTION
## Summary
- add --break-system-packages to pip install step for Alpine base

## Test/QA
- docker build failed without this; pytest not required (openai missing known issue)