### PR TITLE
Run fix: docker requirements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,8 @@ WORKDIR /app
 COPY requirements.txt /app/
 
 # Install Python dependencies
-RUN pip3 install --no-cache-dir -r requirements.txt
+RUN grep -v '^ultralytics' requirements.txt > /tmp/requirements.txt \
+    && pip3 install --no-cache-dir --break-system-packages -r /tmp/requirements.txt
 
 # Copy application source
 COPY src/ /app/src/


### PR DESCRIPTION
## Summary
- skip ultralytics in Docker build to avoid opencv-python source build
- add break-system-packages to allow pip in base image

## Test/QA
- docker build blocked before; pytest not required (openai missing known issue)