### PR TITLE
Run fix: normalize run.sh line endings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,8 +24,9 @@ RUN pip3 install --no-cache-dir -r requirements.txt
 COPY src/ /app/src/
 COPY run.sh /
 
-# Make run script executable
-RUN chmod +x /run.sh
+# Normalize line endings and make executable
+RUN sed -i 's/\r$//' /run.sh \
+    && chmod +x /run.sh
 
 # Labels
 LABEL \


### PR DESCRIPTION
## Summary
- normalize CRLF in run.sh during docker build to avoid bashio\r errors

## Test/QA
- docker compose log showed bashio\r error; pytest not required (openai missing known issue)