### PR TITLE
Run fix: docker compose command override

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,33 @@
+services:
+  app:
+    build:
+      context: .
+      args:
+        BUILD_FROM: ghcr.io/home-assistant/amd64-base:3.19
+    ports:
+      - "8000:8099"
+    command: ["python3", "-m", "src.main"]
+    environment:
+      CAMERA_URL: ${CAMERA_URL:-dummy://}
+      CAMERA_TYPE: ${CAMERA_TYPE:-color}
+      COLOR_CAMERA_URL: ${COLOR_CAMERA_URL:-}
+      THERMAL_CAMERA_URL: ${THERMAL_CAMERA_URL:-}
+      OPENAI_API_KEY: ${OPENAI_API_KEY:-test}
+      MQTT_DISCOVERY: ${MQTT_DISCOVERY:-false}
+      LOG_LEVEL: ${LOG_LEVEL:-INFO}
+services:
+  app:
+    build:
+      context: .
+      args:
+        BUILD_FROM: ghcr.io/home-assistant/amd64-base:3.19
+    ports:
+      - "8000:8099"
+    environment:
+      CAMERA_URL: ${CAMERA_URL:-dummy://}
+      CAMERA_TYPE: ${CAMERA_TYPE:-color}
+      COLOR_CAMERA_URL: ${COLOR_CAMERA_URL:-}
+      THERMAL_CAMERA_URL: ${THERMAL_CAMERA_URL:-}
+      OPENAI_API_KEY: ${OPENAI_API_KEY:-test}
+      MQTT_DISCOVERY: ${MQTT_DISCOVERY:-false}
+      LOG_LEVEL: ${LOG_LEVEL:-INFO}


### PR DESCRIPTION
## Summary
- override docker compose command to run src.main directly
- avoids bashio/supervisor dependency for local docker

## Test/QA
- docker compose logs showed supervisor lookup failures before; pytest not required (openai missing known issue)